### PR TITLE
fix: correct YAML syntax in review-request.yml (line 89)

### DIFF
--- a/.github/workflows/review-request.yml
+++ b/.github/workflows/review-request.yml
@@ -85,7 +85,7 @@ jobs:
               const changedFiles = files.map(f => `- \`${f.filename}\` (${f.status})`).join('\n');
               
               const body = `## 📋 レビュー依頼
-            
+
 **PR**: #${pr.number} - ${pr.title}
 **URL**: ${pr.html_url}
 **著者**: @${pr.user.login}


### PR DESCRIPTION
## 問題

`.github/workflows/review-request.yml` の89行目でYAML構文エラーが発生していました。

## 原因

88行目の空行のインデントが1スペースしかなく、YAMLパーサーが誤解していました。
これは `script: |` ブロック内のJavaScriptテンプレートリテラル内の空行ですが、YAMLパーサーがこの行を誤って解釈していました。

## 修正内容

- 88行目の空行を正しい形式に修正
- テンプレートリテラル内の空行として適切に処理されるように変更

## 関連

- PR #43とは別の問題として対応
- mainブランチでも同じエラーが発生していた既存の問題

## 確認事項

- [ ] GitHub Actionsのチェックが成功することを確認
- [ ] ワークフローが正常に実行されることを確認