### PR TITLE
chore(report): PR Ledger & auto publish

### DIFF
--- a/.github/workflows/pr_ledger.yml
+++ b/.github/workflows/pr_ledger.yml
@@ -1,0 +1,40 @@
+name: PR Ledger (Generate & Publish)
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 0 * * *"   # 00:00 UTC 毎日
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      
+      - name: Auth GH CLI
+        run: echo ok
+      
+      - name: Generate ledger
+        run: node tools/reports/gen-pr-ledger.mjs
+      
+      - name: Commit
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@users.noreply.github.com"
+          git add 99_SYSTEM/Proofs/PR_Ledger_*.md 99_SYSTEM/Proofs/PR_Ledger_LATEST.md
+          git commit -m "chore(report): update PR Ledger" || echo "No changes"
+      
+      - name: Push
+        run: git push
+      
+      - name: Mirror Gate (publish to public)
+        if: always()
+        run: gh workflow run mirror_gate_dispatch.yml -f dry_run=false || true
+

--- a/99_SYSTEM/Proofs/PR_Ledger_2025-11-06-00-01-37.md
+++ b/99_SYSTEM/Proofs/PR_Ledger_2025-11-06-00-01-37.md
@@ -1,0 +1,48 @@
+# PR Ledger — TriHexPhi
+**Generated:** 2025-11-06T00:01:37.897Z
+
+## Quick Summary (latest 20)
+
+- 🟢 open  **#44** fix: correct YAML syntax in review-request.yml (line 89)  ·  fix/review-request-yaml-syntax→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/44)
+- 🟢 open  **#43** feat(s3): implement Seventh Sense Protocol v1.0  ·  feat/s3-protocol-v1→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/43)
+- 🟣 merged  **#42** test: Claude Code Review動作確認  ·  feat/test-claude-review→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/42)
+- 🟢 open  **#37** Harmonia AI rename (safe ASCII) + Φ7 as symbol  ·  feat/harmonia-rename→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/37)
+- 🟣 merged  **#41** feat: S³ Systems bootstrap (LP/CI/Index sync)  ·  feat/s3-systems-bootstrap→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/41)
+- 🟣 merged  **#40** SeventhSense Origin Manifest（命名記録書）追加  ·  feat/seventhsense-manifesto→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/40)
+- 🟣 merged  **#39** SeventhSense ブランドマニフェスト登録  ·  feat/seventhsense-manifesto→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/39)
+- 🟣 merged  **#38** SeventhSense リネーム (Harmonia AI → SeventhSense)  ·  feat/seventhsense-rename→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/38)
+- 🟣 merged  **#36** Integrate Meta × Overdrive + Gate/Mirror/Index unify  ·  feat/integrate-meta-overdrive→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/36)
+- 🟢 open  **#35** ci: update truth_guard.yml to allow mirror_gate_dispatch and make 70_AI_CHRONICLE optional  ·  feat/kyoen-phase2→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/35)
+- 🟣 merged  **#34** chore(remote-truth): unify outputs under origin/main & enable auto-sync  ·  feat/remote-truth-rollout→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/34)
+- 🟢 open  **#33** feat/aios gemini boot  ·  feat/aios-gemini-boot→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/33)
+- 🟣 merged  **#32** Spec as Code v1.0 – Design = Code Implementation  ·  feature/spec-as-code-v1→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/32)
+- 🟣 merged  **#30** Memory Stack v1.0.0 + Governance Baseline  ·  feature/phase1-foundation→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/30)
+- 🟣 merged  **#31** AUTO MODE v1.0 – gated auto deploy  ·  feature/auto-mode-v1→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/31)
+- 🟢 open  **#28** 🔱 Bootstrap v0.0.1実装完了 - 記憶喪失問題解決  ·  test/bootstrap-v4→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/28)
+- 🟢 open  **#27** 🧪 Test: AI Auto Review System v2 (Fixed)  ·  test/auto-review-v2→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/27)
+- 🟢 open  **#26** 🧪 Test: AI Auto Review System v1  ·  test/auto-review-v1→main  ·  [link](https://github.com/kyousuke10000/TriHexPhi/pull/26)
+
+---
+
+## Full Ledger
+
+| # | title | state | branch | updated | author | link |
+|---:|---|---|---|---|---|---|
+| 44 | fix: correct YAML syntax in review-request.yml (line 89) | open | fix/review-request-yaml-syntax→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/44) |
+| 43 | feat(s3): implement Seventh Sense Protocol v1.0 | open | feat/s3-protocol-v1→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/43) |
+| 42 | test: Claude Code Review動作確認 | merged | feat/test-claude-review→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/42) |
+| 37 | Harmonia AI rename (safe ASCII) + Φ7 as symbol | open | feat/harmonia-rename→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/37) |
+| 41 | feat: S³ Systems bootstrap (LP/CI/Index sync) | merged | feat/s3-systems-bootstrap→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/41) |
+| 40 | SeventhSense Origin Manifest（命名記録書）追加 | merged | feat/seventhsense-manifesto→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/40) |
+| 39 | SeventhSense ブランドマニフェスト登録 | merged | feat/seventhsense-manifesto→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/39) |
+| 38 | SeventhSense リネーム (Harmonia AI → SeventhSense) | merged | feat/seventhsense-rename→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/38) |
+| 36 | Integrate Meta × Overdrive + Gate/Mirror/Index unify | merged | feat/integrate-meta-overdrive→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/36) |
+| 35 | ci: update truth_guard.yml to allow mirror_gate_dispatch and make 70_AI_CHRONICLE optional | open | feat/kyoen-phase2→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/35) |
+| 34 | chore(remote-truth): unify outputs under origin/main & enable auto-sync | merged | feat/remote-truth-rollout→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/34) |
+| 33 | feat/aios gemini boot | open | feat/aios-gemini-boot→main | 2025-11-05 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/33) |
+| 32 | Spec as Code v1.0 – Design = Code Implementation | merged | feature/spec-as-code-v1→main | 2025-11-02 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/32) |
+| 30 | Memory Stack v1.0.0 + Governance Baseline | merged | feature/phase1-foundation→main | 2025-11-02 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/30) |
+| 31 | AUTO MODE v1.0 – gated auto deploy | merged | feature/auto-mode-v1→main | 2025-11-02 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/31) |
+| 28 | 🔱 Bootstrap v0.0.1実装完了 - 記憶喪失問題解決 | open | test/bootstrap-v4→main | 2025-10-27 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/28) |
+| 27 | 🧪 Test: AI Auto Review System v2 (Fixed) | open | test/auto-review-v2→main | 2025-10-26 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/27) |
+| 26 | 🧪 Test: AI Auto Review System v1 | open | test/auto-review-v1→main | 2025-10-26 | kyousuke10000 | [open](https://github.com/kyousuke10000/TriHexPhi/pull/26) |

--- a/99_SYSTEM/Proofs/PR_Ledger_LATEST.md
+++ b/99_SYSTEM/Proofs/PR_Ledger_LATEST.md
@@ -1,0 +1,4 @@
+<!-- auto-generated pointer -->
+
+See: **99_SYSTEM/Proofs/PR_Ledger_2025-11-06-00-01-37.md**
+

--- a/tools/reports/gen-pr-ledger.mjs
+++ b/tools/reports/gen-pr-ledger.mjs
@@ -1,0 +1,52 @@
+import { execSync } from 'node:child_process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+
+function sh(cmd){ return execSync(cmd,{encoding:'utf8'}).trim(); }
+
+const repo = sh('basename -s .git "$(git config --get remote.origin.url | sed -E \'s#.*/##\')"');
+const now = new Date();
+const stamp = now.toISOString().slice(0,19).replace(/[:T]/g,'-');
+const outDir = '99_SYSTEM/Proofs';
+mkdirSync(outDir, { recursive: true });
+
+const json = sh('gh pr list --state all --limit 200 --json number,title,author,headRefName,baseRefName,state,mergeable,mergedAt,createdAt,updatedAt,url');
+const items = JSON.parse(json).sort((a,b)=> new Date(b.updatedAt)-new Date(a.updatedAt));
+
+const top = items.slice(0,20);
+const lines = [];
+
+lines.push(`# PR Ledger — ${repo}`);
+lines.push(`**Generated:** ${now.toISOString()}`);
+lines.push('');
+
+lines.push('## Quick Summary (latest 20)');
+lines.push('');
+
+for (const p of top) {
+  const badge = p.state === 'MERGED' ? '🟣 merged' : p.state === 'OPEN' ? '🟢 open' : '⚫️ closed';
+  lines.push(`- ${badge}  **#${p.number}** ${p.title}  ·  ${p.headRefName}→${p.baseRefName}  ·  [link](${p.url})`);
+}
+
+lines.push('');
+lines.push('---');
+lines.push('');
+lines.push('## Full Ledger');
+lines.push('');
+lines.push('| # | title | state | branch | updated | author | link |');
+lines.push('|---:|---|---|---|---|---|---|');
+
+for (const p of items) {
+  const upd = p.updatedAt?.slice(0,10) ?? '';
+  const branch = `${p.headRefName}→${p.baseRefName}`;
+  lines.push(`| ${p.number} | ${p.title.replace(/\|/g,'／')} | ${p.state.toLowerCase()} | ${branch} | ${upd} | ${p.author?.login ?? ''} | [open](${p.url}) |`);
+}
+
+const outFile = `${outDir}/PR_Ledger_${stamp}.md`;
+writeFileSync(outFile, lines.join('\n'), 'utf8');
+
+// 入口ファイルを更新（常に最新へのポインタ）
+writeFileSync(`${outDir}/PR_Ledger_LATEST.md`,
+  `<!-- auto-generated pointer -->\n\nSee: **${outFile}**\n\n`,'utf8');
+
+console.log('Wrote:', outFile);
+


### PR DESCRIPTION
## 概要

PR Ledger（構想ダイジェスト）の自動生成・公開機能を追加します。

## 機能

- **すべてのPR（Open/Merged/Closed）を1つのMDに集約**
  - 番号/タイトル/状態/ブランチ/作成者/更新日/URL
  - 直近20件のサマリと全履歴テーブルを出力

- **自動更新**
  - 毎日00:00 UTCに自動生成
  - 手動トリガー対応（workflow_dispatch）

- **Public Mirror への自動公開**
  - Proofsに保存し、Mirror GateでPublic Mirrorへ反映
  - PR_Ledger_LATEST.md で常に最新を指すポインタを提供

## 生成ファイル

- `99_SYSTEM/Proofs/PR_Ledger_YYYY-MM-DD-hh-mm-ss.md` - 世代ファイル
- `99_SYSTEM/Proofs/PR_Ledger_LATEST.md` - 最新へのポインタ

## 公開側の入口

- **最新へのポインタ（Web版AI向け）**: https://raw.githubusercontent.com/kyousuke10000/TriHexPhi-public/main/99_SYSTEM/Proofs/PR_Ledger_LATEST.md
- 世代ファイルは PR_Ledger_*.md がどんどん積み上がる（監査・追跡に強い）

## 関連

- Mirror Gate連携済み（自動公開）
- Public Mirror の index.md へのリンク追加は別途対応可能